### PR TITLE
feat: add gender filter to room selection and filtering components

### DIFF
--- a/components/room-selection.tsx
+++ b/components/room-selection.tsx
@@ -50,7 +50,6 @@ const RoomSelection: React.FC<RoomSelectionProps> = ({ onRoomSelected, studentPr
   const [availableRoomsForChange, setAvailableRoomsForChange] = useState<(Room & { hostelName: string; floorName: string; price: number })[]>([]);
   const [selectedNewRoom, setSelectedNewRoom] = useState<Room & { hostelName: string; floorName: string; price: number } | null>(null);
   const [isChangingRoom, setIsChangingRoom] = useState(false);
-
   // Custom hooks
   const { existingAllocation, allocationRoomDetails, checkExistingAllocation } = useStudentAllocation(hostels);
   const { filteredRooms, availableRoomsCount, selectedHostelData } = useRoomFiltering(hostels, {
@@ -58,7 +57,9 @@ const RoomSelection: React.FC<RoomSelectionProps> = ({ onRoomSelected, studentPr
     selectedFloor,
     searchTerm,
     priceFilter,
-    capacityFilter: 'any'
+    capacityFilter: 'any',
+    // Only apply gender filter for first-time selection (no existing allocation)
+    studentGender: !existingAllocation && studentProfile?.gender ? studentProfile.gender as 'Male' | 'Female' : undefined
   });
 
   useEffect(() => {
@@ -242,8 +243,7 @@ const RoomSelection: React.FC<RoomSelectionProps> = ({ onRoomSelected, studentPr
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto p-6 space-y-6">
-        {/* Filters */}
+      <div className="flex-1 overflow-auto p-6 space-y-6">        {/* Filters */}
         <RoomFilters
           hostels={hostels}
           selectedHostel={selectedHostel}
@@ -254,6 +254,8 @@ const RoomSelection: React.FC<RoomSelectionProps> = ({ onRoomSelected, studentPr
           onFloorChange={setSelectedFloor}
           onSearchChange={setSearchTerm}
           onPriceFilterChange={setPriceFilter}
+          studentGender={studentProfile?.gender as 'Male' | 'Female'}
+          showGenderFilter={!existingAllocation && !!studentProfile?.gender}
         />
 
         {/* Hostel Info */}

--- a/components/room-selection/room-filters.tsx
+++ b/components/room-selection/room-filters.tsx
@@ -16,6 +16,8 @@ interface RoomFiltersProps {
   onFloorChange: (value: string) => void;
   onSearchChange: (value: string) => void;
   onPriceFilterChange: (value: string) => void;
+  studentGender?: 'Male' | 'Female';
+  showGenderFilter?: boolean;
 }
 
 const RoomFilters: React.FC<RoomFiltersProps> = ({
@@ -27,14 +29,20 @@ const RoomFilters: React.FC<RoomFiltersProps> = ({
   onHostelChange,
   onFloorChange,
   onSearchChange,
-  onPriceFilterChange
+  onPriceFilterChange,
+  studentGender,
+  showGenderFilter
 }) => {
   const selectedHostelData = hostels.find(h => h.id === selectedHostel);
 
   return (
-    <Card>
-      <CardHeader>
+    <Card>      <CardHeader>
         <CardTitle>Filter Rooms</CardTitle>
+        {showGenderFilter && studentGender && (
+          <p className="text-sm text-blue-600 bg-blue-50 p-2 rounded">
+            📍 Showing {studentGender} and Mixed gender rooms only
+          </p>
+        )}
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/hooks/useRoomFiltering.ts
+++ b/hooks/useRoomFiltering.ts
@@ -9,6 +9,7 @@ interface FilterOptions {
   searchTerm: string;
   priceFilter: string;
   capacityFilter: string;
+  studentGender?: 'Male' | 'Female';
 }
 
 export const useRoomFiltering = (hostels: Hostel[], filters: FilterOptions) => {
@@ -55,11 +56,16 @@ export const useRoomFiltering = (hostels: Hostel[], filters: FilterOptions) => {
           return room.price >= min;
         }
       });
-    }
-
-    // Apply capacity filter
+    }    // Apply capacity filter
     if (filters.capacityFilter && filters.capacityFilter !== 'any') {
       rooms = rooms.filter(room => room.capacity.toString() === filters.capacityFilter);
+    }
+
+    // Apply gender filter for first-time selection
+    if (filters.studentGender) {
+      rooms = rooms.filter(room => 
+        room.gender === filters.studentGender || room.gender === 'Mixed'
+      );
     }
 
     // Sort by availability first, then by room number


### PR DESCRIPTION
## Summary by Sourcery

Add gender-based filtering to room selection and filtering components to only show rooms matching the student’s gender or mixed-gender rooms, and display a notice when the filter is active.

New Features:
- Extend RoomFilters component to accept studentGender and showGenderFilter props and display a banner when gender filtering is applied
- Implement gender filter in useRoomFiltering hook to include only rooms matching the student’s gender or mixed-gender rooms
- Update RoomSelection component to pass student gender into filters only for first-time allocations and conditionally enable the gender filter